### PR TITLE
Fix style escaping

### DIFF
--- a/example/components/x-button/x-button.html
+++ b/example/components/x-button/x-button.html
@@ -1,0 +1,29 @@
+<style>
+  button {
+    --bg: #ececec;
+    --bc: #000;
+    --br: 3px;
+    --pb: calc(1rem / 4);
+    --pi: calc(1rem / 3);
+
+    background: var(--bg);
+    border: 1px solid var(--bc);
+    border-radius: var(--br);
+    cursor: pointer;
+
+    padding-block: var(--pb);
+    padding-inline: var(--pi);
+
+    font-size: inherit;
+  }
+
+  :host {
+    &[primary] button {
+      --bg: lightgreen;
+    }
+  }
+</style>
+
+<button>
+  <slot></slot>
+</button>

--- a/example/index.html
+++ b/example/index.html
@@ -18,6 +18,9 @@
     </style>
   </head>
   <body>
+    <div>
+      <x-button primary>Click this</x-button>
+    </div>
     <page-header>
       <h1 class="title" slot="title">Plugin Custom Element</h1>
       <live-clock hydrate></live-clock>

--- a/plugin/parsers/HtmlCustomElements/findHtmlElementFiles/findHtmlElementFiles.test.ts
+++ b/plugin/parsers/HtmlCustomElements/findHtmlElementFiles/findHtmlElementFiles.test.ts
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { findHtmlElementFiles } from './findHtmlElementFiles';
+import { findHtmlElementFiles } from './findHtmlElementFiles.js';
 
 const fixtureDir = fileURLToPath(
   join(dirname(import.meta.url), '..', 'fixtures'),

--- a/plugin/parsers/HtmlCustomElements/injectLinkTags/injectLinkTags.test.ts
+++ b/plugin/parsers/HtmlCustomElements/injectLinkTags/injectLinkTags.test.ts
@@ -1,4 +1,4 @@
-import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements';
+import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements.js';
 import {
   appendChild,
   createDocument,
@@ -10,7 +10,7 @@ import path from 'node:path';
 import { parseFragment } from 'parse5';
 import { describe, expect, it } from 'vitest';
 
-import { transformLinkUrls } from './injectLinkTags';
+import { transformLinkUrls } from './injectLinkTags.js';
 
 describe('transformLinkUrls', () => {
   it('Does NOT transforms link URLs if light DOM', async () => {
@@ -89,17 +89,3 @@ describe('transformLinkUrls', () => {
     expect(href).toContain('tags/x-component.css');
   });
 });
-
-function newDoc(content: string): string {
-  return createDocument(
-    `
-    <!doctype html>
-      <html>
-        <head></head>
-        <body>
-          ${content || ''}
-        </body>
-      </html>
-      `,
-  );
-}

--- a/plugin/parsers/HtmlCustomElements/injectScripts/injectScripts.test.ts
+++ b/plugin/parsers/HtmlCustomElements/injectScripts/injectScripts.test.ts
@@ -1,4 +1,4 @@
-import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements';
+import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements.js';
 import {
   createDocument,
   createElement,
@@ -12,8 +12,8 @@ import path from 'node:path';
 import { parseFragment } from 'parse5';
 import { describe, expect, it } from 'vitest';
 
-import { injectScripts, transformShadowScripts } from './injectScripts';
-import { findTag } from '@/plugin/util/parse5';
+import { injectScripts, transformShadowScripts } from './injectScripts.js';
+import { findTag } from '@/plugin/util/parse5.js';
 
 describe('injectScripts', () => {
   it('Injects scripts from a RequiredElement list into the DOM', async () => {

--- a/plugin/parsers/HtmlCustomElements/loadAndParseHtmlElements/loadAndParseHtmlElements.test.ts
+++ b/plugin/parsers/HtmlCustomElements/loadAndParseHtmlElements/loadAndParseHtmlElements.test.ts
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { loadAndParseHtmlElements } from './loadAndParseHtmlElements';
+import { loadAndParseHtmlElements } from './loadAndParseHtmlElements.js';
 
 const fixtureDir = fileURLToPath(
   join(dirname(import.meta.url), '..', 'fixtures'),

--- a/plugin/parsers/HtmlCustomElements/parseHtmlElement/parseHtmlElement.test.ts
+++ b/plugin/parsers/HtmlCustomElements/parseHtmlElement/parseHtmlElement.test.ts
@@ -10,14 +10,14 @@ import { fileURLToPath } from 'node:url';
 import { parseFragment } from 'parse5';
 import { describe, expect, it } from 'vitest';
 
-import { parseHtmlElement } from './parseHtmlElement';
+import { parseHtmlElement } from './parseHtmlElement.js';
 
 const fixtureDir = fileURLToPath(
   join(dirname(import.meta.url), '..', 'fixtures'),
 );
 
 describe('parseHtmlElement', () => {
-  it('Parses element content', async () => {});
+  it('Parses element content', async () => { });
 
   it('Extracts <style> tags', async () => {
     const fragment = createDocumentFragment();

--- a/plugin/parsers/HtmlCustomElements/parseRequiredHtmlElements/parseRequiredHtmlElements.test.ts
+++ b/plugin/parsers/HtmlCustomElements/parseRequiredHtmlElements/parseRequiredHtmlElements.test.ts
@@ -1,9 +1,8 @@
-import { fixtureDir } from '../test-helpers';
+import { fixtureDir } from '../test-helpers.js';
 import { createElement } from '@web/parse5-utils';
 import { describe, expect, it } from 'vitest';
 
-import { parseRequiredHtmlElements } from './parseRequiredHtmlElements';
-import { map } from '@/utility/arrays';
+import { parseRequiredHtmlElements } from './parseRequiredHtmlElements.js';
 
 describe('parseRequiredHtmlElements', () => {
   it('Parses provided elements', async () => {
@@ -18,8 +17,7 @@ describe('parseRequiredHtmlElements', () => {
 
   it('Parses nested elements', async () => {
     const customElements = [createElement('element-with-nested')];
-    const sourceFiles = map(
-      ['my-element.html', 'element-with-nested.html'],
+    const sourceFiles = ['my-element.html', 'element-with-nested.html'].map(
       fixtureDir,
     );
 

--- a/plugin/parsers/HtmlCustomElements/replaceElementsContent/replaceElementsContent.test.ts
+++ b/plugin/parsers/HtmlCustomElements/replaceElementsContent/replaceElementsContent.test.ts
@@ -1,5 +1,5 @@
-import { findTag } from '../../../util/parse5';
-import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements';
+import { findTag } from '../../../util/parse5.js';
+import { RequiredElement } from '../parseRequiredHtmlElements/parseRequiredHtmlElements.js';
 import {
   Element,
   appendChild,
@@ -15,7 +15,7 @@ import {
 import { parseFragment } from 'parse5';
 import { describe, expect, it } from 'vitest';
 
-import { replaceElementsContent } from './replaceElementsContent';
+import { replaceElementsContent } from './replaceElementsContent.js';
 
 describe('replaceElementsContent', () => {
   it('Replaces custom element content', async () => {

--- a/plugin/parsers/findCustomElements/findCustomElements.test.ts
+++ b/plugin/parsers/findCustomElements/findCustomElements.test.ts
@@ -2,7 +2,7 @@ import { appendChild, createElement, getTagName } from '@web/parse5-utils';
 import { parse, parseFragment } from 'parse5';
 import { describe, expect, it } from 'vitest';
 
-import { findCustomElements, reservedElements } from './findCustomElements';
+import { findCustomElements, reservedElements } from './findCustomElements.js';
 
 describe('findCustomElements', () => {
   it('Finds elements in a Document', () => {

--- a/plugin/plugin-custom-element.ts
+++ b/plugin/plugin-custom-element.ts
@@ -22,7 +22,7 @@ import {
 } from './parsers/HtmlCustomElements/parseRequiredHtmlElements/parseRequiredHtmlElements.js';
 import { replaceElementsContent } from './parsers/HtmlCustomElements/replaceElementsContent/replaceElementsContent.js';
 import { findCustomElements } from './parsers/index.js';
-import { findTag, serializeWithStringifiedTags } from './util/parse5.js';
+import { findTag, serializeRawStringsForTag } from './util/parse5.js';
 
 const cwd = process.cwd();
 
@@ -75,7 +75,7 @@ export function pluginCustomElement({
           appendChild(body, script);
         }
 
-        return serializeWithStringifiedTags(document, 'style');
+        return serializeRawStringsForTag(document, 'style');
       },
     },
   } as PluginOption;

--- a/plugin/plugin-custom-element.ts
+++ b/plugin/plugin-custom-element.ts
@@ -1,8 +1,12 @@
 import {
   Element,
+  Node,
   appendChild,
   findElement,
+  findElements,
   getAttribute,
+  getChildNodes,
+  remove,
 } from '@web/parse5-utils';
 import path from 'node:path';
 import { parse, serialize } from 'parse5';
@@ -22,7 +26,7 @@ import {
 } from './parsers/HtmlCustomElements/parseRequiredHtmlElements/parseRequiredHtmlElements.js';
 import { replaceElementsContent } from './parsers/HtmlCustomElements/replaceElementsContent/replaceElementsContent.js';
 import { findCustomElements } from './parsers/index.js';
-import { findTag } from './util/parse5.js';
+import { findTag, replaceNode } from './util/parse5.js';
 
 const cwd = process.cwd();
 
@@ -75,7 +79,41 @@ export function pluginCustomElement({
           appendChild(body, script);
         }
 
-        return serialize(document);
+        let styleContents = [];
+        const styleElements = findElements(document, (element) => {
+          if (element.nodeName === 'style') {
+            return true;
+          }
+          return false;
+        });
+
+        for (const style of styleElements) {
+          const children = getChildNodes(style);
+          const content = children
+            .map((child: Node) => {
+              return child.value;
+            })
+            .join('\n');
+          styleContents.push(content);
+          const index = styleContents.indexOf(content);
+
+          style.childNodes = [createTextNode(`{{replaceStyle[${index}]}}`)];
+
+          // replaceNode(style, createTextNode('<!--style[]-->'));
+
+          // remove(style);
+        }
+
+        let serialized = serialize(document);
+
+        for (let i = 0; i < styleContents.length; i++) {
+          serialized = serialized.replace(
+            `{{replaceStyle[${i}]}}`,
+            styleContents[i],
+          );
+        }
+
+        return serialized;
       },
     },
   } as PluginOption;
@@ -96,4 +134,14 @@ function processShadowedItems(rootDir: string, elements: RequiredElement[]) {
       transformShadowScripts(template, element, rootDir);
     }
   }
+}
+
+function createTextNode(text: string) {
+  return {
+    nodeName: '#text',
+    value: text,
+    parentNode: null,
+    attrs: [],
+    __location: undefined,
+  };
 }

--- a/plugin/util/parse5.test.ts
+++ b/plugin/util/parse5.test.ts
@@ -1,0 +1,29 @@
+import { appendChild, createElement, findElement } from '@web/parse5-utils';
+import { parse } from 'parse5';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createTextNode,
+  findTag,
+  serializeWithStringifiedTags,
+} from './parse5.js';
+
+describe('serializeWithStringifiedTags', () => {
+  it('does not escape content within tag', () => {
+    const doc = parse('<!doctype html><html><head></head><body></body></html>');
+
+    const styleTags = Array.from({ length: 5 }, () => {
+      const tag = createElement('style');
+      tag.childNodes = [createTextNode('.test { &.test2 { color: red; } }')];
+      return tag;
+    });
+
+    const head = findElement(doc, findTag('head'));
+    for (const tag of styleTags) {
+      appendChild(head, tag);
+    }
+
+    const result = serializeWithStringifiedTags(doc, 'style');
+    expect(result).toContain('&.test2');
+  });
+});

--- a/plugin/util/parse5.test.ts
+++ b/plugin/util/parse5.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createTextNode,
   findTag,
-  serializeWithStringifiedTags,
+  serializeRawStringsForTag,
 } from './parse5.js';
 
 describe('serializeWithStringifiedTags', () => {
@@ -23,7 +23,7 @@ describe('serializeWithStringifiedTags', () => {
       appendChild(head, tag);
     }
 
-    const result = serializeWithStringifiedTags(doc, 'style');
+    const result = serializeRawStringsForTag(doc, 'style');
     expect(result).toContain('&.test2');
   });
 });

--- a/plugin/util/parse5.ts
+++ b/plugin/util/parse5.ts
@@ -20,7 +20,7 @@ export function replaceNode(target: Element, replacer: Element): void {
   remove(target);
 }
 
-export function serializeWithStringifiedTags(parent: Node, tagName: string) {
+export function serializeRawStringsForTag(parent: Node, tagName: string) {
   const elementContents = [];
   const elements = findElements(parent, (element) => {
     if (element.nodeName === tagName) {

--- a/plugin/util/parse5.ts
+++ b/plugin/util/parse5.ts
@@ -1,10 +1,13 @@
+import type { Element, Node } from '@web/parse5-utils';
 import {
-  Element,
+  findElements,
+  getChildNodes,
   getParentNode,
   getTagName,
   insertBefore,
   remove,
 } from '@web/parse5-utils';
+import { serialize } from 'parse5';
 
 export function findTag(tagName: string): Element {
   return (el: Element) => {
@@ -15,4 +18,40 @@ export function findTag(tagName: string): Element {
 export function replaceNode(target: Element, replacer: Element): void {
   insertBefore(getParentNode(target), replacer, target);
   remove(target);
+}
+
+export function serializeWithStringifiedTags(parent: Node, tagName: string) {
+  const elementContents = [];
+  const elements = findElements(parent, (element) => {
+    if (element.nodeName === tagName) {
+      return true;
+    }
+    return false;
+  });
+
+  for (const element of elements) {
+    const children = getChildNodes(element);
+    const content = children.map((c: Node) => c.value).join('\n');
+    elementContents.push(content);
+
+    const index = elementContents.length - 1;
+    element.childNodes = [createTextNode(`{{replacer[${index}]}}`)];
+  }
+
+  let serialized = serialize(parent);
+  for (let i = 0; i < elementContents.length; i++) {
+    serialized = serialized.replace(`{{replacer[${i}]}}`, elementContents[i]);
+  }
+
+  return serialized;
+}
+
+export function createTextNode(text: string): Node {
+  return {
+    nodeName: '#text',
+    value: text,
+    parentNode: null,
+    attrs: [],
+    __location: undefined,
+  };
 }


### PR DESCRIPTION
parse5 escapes strings so `&.selector` was turning into `&amp;.selector` which I do not want for style tags. This ensures raw strings for style tags. 